### PR TITLE
Resolved. warning on ruby 2.7

### DIFF
--- a/lib/syobocalite.rb
+++ b/lib/syobocalite.rb
@@ -41,7 +41,7 @@ module Syobocalite
       "User-Agent" => "Syobocalite v#{Syobocalite::VERSION}",
     }
 
-    open("http://cal.syoboi.jp/cal_chk.php?#{params.to_param}", headers).read
+    URI.open("http://cal.syoboi.jp/cal_chk.php?#{params.to_param}", headers).read
   end
   private_class_method :fetch
 end


### PR DESCRIPTION
```
/home/runner/work/syobocalite/syobocalite/lib/syobocalite.rb:44: warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open
```

https://github.com/sue445/syobocalite/runs/370498939