### PR TITLE
Drop support ruby 2.3 and 2.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,17 +17,11 @@ jobs:
 
       matrix:
         ruby:
-          - 2.3.0
-          - 2.4.0
           - 2.5.0
           - 2.6.0
           - 2.7.0
           - 2.8.0-dev
         include:
-          - ruby: 2.3.0
-            runner: ubuntu-16.04
-          - ruby: 2.4.0
-            runner: ubuntu-latest
           - ruby: 2.5.0
             runner: ubuntu-latest
           - ruby: 2.6.0

--- a/syobocalite.gemspec
+++ b/syobocalite.gemspec
@@ -34,6 +34,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = ">= 2.5.0"
+
   spec.add_dependency "activesupport"
   spec.add_dependency "multi_xml"
 


### PR DESCRIPTION
`URI.open` available since ruby 2.5

c.f. https://github.com/sue445/syobocalite/pull/13/checks?check_run_id=370512833